### PR TITLE
Rewrite blob saving + some other stuff

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -5,7 +5,6 @@ from discord.ext import commands
 import aiohttp
 import aiosqlite
 import asyncio
-import concurrent.futures
 import discord
 import glob
 import os
@@ -92,17 +91,17 @@ async def startup():
             ''')
         await db.commit()
 
-    with concurrent.futures.ThreadPoolExecutor() as pool:
-        async with aiohttp.ClientSession() as session:
-            bot.get_cog('Utilities').shsh_pool = pool
-            bot.session = session
+    async with aiohttp.ClientSession() as session:
+        cpu_count = min(32, (await asyncio.to_thread(os.cpu_count) or 1) + 4)
+        bot.get_cog('Utilities').sem = asyncio.Semaphore(cpu_count)
+        bot.session = session
 
-            try:
-                await bot.start(os.environ['AUTOTSS_TOKEN'])
-            except discord.LoginFailure:
-                sys.exit("[ERROR] Token invalid, make sure the 'AUTOTSS_TOKEN' environment variable is set to your bot token. Exiting.")
-            except discord.PrivilegedIntentsRequired:
-                sys.exit("[ERROR] Server Members Intent not enabled, go to 'https://discord.com/developers/applications' and enable the Server Members Intent. Exiting.")
+        try:
+            await bot.start(os.environ['AUTOTSS_TOKEN'])
+        except discord.LoginFailure:
+            sys.exit("[ERROR] Token invalid, make sure the 'AUTOTSS_TOKEN' environment variable is set to your bot token. Exiting.")
+        except discord.PrivilegedIntentsRequired:
+            sys.exit("[ERROR] Server Members Intent not enabled, go to 'https://discord.com/developers/applications' and enable the Server Members Intent. Exiting.")
 
 
 if __name__ == '__main__':

--- a/bot.py
+++ b/bot.py
@@ -98,6 +98,7 @@ async def startup():
                 sql = 'UPDATE uptime SET start_time = ?'
 
         await db.execute(sql, (await asyncio.to_thread(time.time),))
+        await db.commit()
 
     async with aiohttp.ClientSession() as session:
         cpu_count = min(32, (await asyncio.to_thread(os.cpu_count) or 1) + 4)

--- a/bot.py
+++ b/bot.py
@@ -5,6 +5,7 @@ from discord.ext import commands
 import aiohttp
 import aiosqlite
 import asyncio
+import concurrent.futures
 import discord
 import glob
 import os
@@ -91,15 +92,17 @@ async def startup():
             ''')
         await db.commit()
 
-    async with aiohttp.ClientSession() as session:
-        bot.session = session
+    with concurrent.futures.ThreadPoolExecutor() as pool:
+        async with aiohttp.ClientSession() as session:
+            bot.get_cog('Utilities').shsh_pool = pool
+            bot.session = session
 
-        try:
-            await bot.start(os.environ['AUTOTSS_TOKEN'])
-        except discord.LoginFailure:
-            sys.exit("[ERROR] Token invalid, make sure the 'AUTOTSS_TOKEN' environment variable is set to your bot token. Exiting.")
-        except discord.PrivilegedIntentsRequired:
-            sys.exit("[ERROR] Server Members Intent not enabled, go to 'https://discord.com/developers/applications' and enable the Server Members Intent. Exiting.")
+            try:
+                await bot.start(os.environ['AUTOTSS_TOKEN'])
+            except discord.LoginFailure:
+                sys.exit("[ERROR] Token invalid, make sure the 'AUTOTSS_TOKEN' environment variable is set to your bot token. Exiting.")
+            except discord.PrivilegedIntentsRequired:
+                sys.exit("[ERROR] Server Members Intent not enabled, go to 'https://discord.com/developers/applications' and enable the Server Members Intent. Exiting.")
 
 
 if __name__ == '__main__':

--- a/cogs/device.py
+++ b/cogs/device.py
@@ -1,4 +1,3 @@
-from aioify import aioify
 from discord.ext import commands
 from discord.errors import NotFound, Forbidden
 from views.buttons import SelectView, PaginatorView
@@ -15,7 +14,6 @@ import shutil
 class DeviceCog(commands.Cog, name='Device'):
     def __init__(self, bot):
         self.bot = bot
-        self.shutil = aioify(shutil, name='shutil')
         self.utils = self.bot.get_cog('Utilities')
 
     @commands.group(name='device', aliases=('devices', 'd'), help='Device management commands.', invoke_without_command=True)
@@ -410,7 +408,7 @@ class DeviceCog(commands.Cog, name='Device'):
                 message = await message.edit(embed=embed)
 
             else:
-                await self.shutil.rmtree(f"Data/Blobs/{devices[num]['ecid']}")
+                await asyncio.to_thread(shutil.rmtree, f"Data/Blobs/{devices[num]['ecid']}")
 
                 embed = discord.Embed(title='Remove Device')
                 embed.description = f"SHSH Blobs from `{devices[num]['name']}`: [Click here]({url})"

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -71,6 +71,9 @@ class EventsCog(commands.Cog, name='Events'):
                     elif any(oldfirm['signed'] == False for oldfirm in self._api[device] if oldfirm['buildid'] == firm['buildid']): # If firmware has been resigned
                         print(f"[AUTO] iOS {firm['version']} ({firm['buildid']}) has been resigned for {device}, saving SHSH blobs.")
 
+                    else:
+                        print('[AUTO] Saving SHSH Blobs.')
+
                     async with aiosqlite.connect('Data/autotss.db') as db, db.execute('SELECT * from autotss WHERE enabled = ?', (True,)) as cursor:
                         data = await cursor.fetchall()
 

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -39,6 +39,7 @@ class EventsCog(commands.Cog, name='Events'):
             await asyncio.sleep(300)
             return
 
+        self.utils.saving_blobs = True
         async with self.bot.session.get('https://api.ipsw.me/v4/devices') as resp:
             devices = [d for d in await resp.json() if any(x in d['identifier'] for x in ('iPhone', 'AppleTV', 'iPod', 'iPad'))]
 
@@ -66,7 +67,6 @@ class EventsCog(commands.Cog, name='Events'):
                     elif any(oldfirm['signed'] == False for oldfirm in self._api[device] if oldfirm['buildid'] == firm['buildid']): # If firmware has been resigned
                         print(f"[AUTO] iOS {firm['version']} ({firm['buildid']}) has been resigned for {device}, saving SHSH blobs.")
 
-                    self.utils.saving_blobs = True
                     async with aiosqlite.connect('Data/autotss.db') as db, db.execute('SELECT * from autotss WHERE enabled = ?', (True,)) as cursor:
                         data = await cursor.fetchall()
 
@@ -74,7 +74,6 @@ class EventsCog(commands.Cog, name='Events'):
                     data = await asyncio.gather(*[self.utils.sem_call(self.utils.save_user_blobs, user_data[0], json.loads(user_data[1])) for user_data in data])
                     finish_time = round(await asyncio.to_thread(time.time) - start_time)
 
-                    self.utils.saving_blobs = False
                     blobs_saved = sum(user['blobs_saved'] for user in data)
                     devices_saved = sum(user['devices_saved'] for user in data)
 
@@ -95,6 +94,7 @@ class EventsCog(commands.Cog, name='Events'):
             else:
                 self._api[device] = api[device]
 
+        self.utils.saving_blobs = False
         await asyncio.sleep(300)
 
     @commands.Cog.listener()

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -1,22 +1,18 @@
-from aioify import aioify
 from discord.ext import commands, tasks
 
 import aiosqlite
 import asyncio
 import discord
 import json
-import os
-import shutil
+import time
 
 
 class EventsCog(commands.Cog, name='Events'):
     def __init__(self, bot):
         self.bot = bot
-        self.os = aioify(os, name='os')
-        self.shutil = aioify(shutil, name='shutil')
         self.utils = self.bot.get_cog('Utilities')
         self.auto_clean_db.start()
-        self.signing_party_detection.start()
+        self.blob_saver.start()
 
     @tasks.loop()
     async def auto_clean_db(self) -> None:
@@ -35,8 +31,13 @@ class EventsCog(commands.Cog, name='Events'):
         await asyncio.sleep(300)
 
     @tasks.loop()
-    async def signing_party_detection(self) -> None:
+    async def blob_saver(self) -> None:
         await self.bot.wait_until_ready()
+
+        if self.utils.saving_blobs:
+            print(f"[AUTO] SHSH blob saver already running, continuing.")
+            await asyncio.sleep(300)
+            return
 
         async with self.bot.session.get('https://api.ipsw.me/v4/devices') as resp:
             devices = [d for d in await resp.json() if any(x in d['identifier'] for x in ('iPhone', 'AppleTV', 'iPod', 'iPad'))]
@@ -51,31 +52,50 @@ class EventsCog(commands.Cog, name='Events'):
             self._api = api
             return
 
-        for device in self._api.keys():
-            for firm in [x for x in self._api[device] if x['signed'] == False]:
-                if any(new_firm['signed'] == True for new_firm in api[device] if new_firm['buildid'] == firm['buildid']):
-                    print(f"[SIGN] Detected resigned firmware for: {device}, iOS {firm['version']}")
-                    await self.utils.update_auto_saver_frequency(60) # Set blob saver frequency to 1 minute
-                    tss = self.bot.get_cog('TSS') # Get TSS class
-                    tss.blobs_loop = False
+        for device in api.keys():
+            if device not in self._api.keys(): # If new device is added to the API
+                print(f"[AUTO] New device has been detected: {device}.")
+                self._api[device] = api[device]
+                continue
 
-                    tss.auto_blob_saver.cancel() # Restart auto blob saver
-                    await asyncio.sleep(1)
-                    await self.utils.update_device_count()
-                    tss.auto_blob_saver.start()
+            for firm in api[device]:
+                if firm['signed'] == True:
+                    if firm not in self._api[device]: # If firmware was just released
+                        print(f"[AUTO] iOS {firm['version']} ({firm['buildid']}) has been released, saving SHSH blobs.")
 
-                    await asyncio.sleep(600) # Wait 10 minutes
+                    elif any(oldfirm['signed'] == False for oldfirm in self._api[device] if oldfirm['buildid'] == firm['buildid']): # If firmware has been resigned
+                        print(f"[AUTO] iOS {firm['version']} ({firm['buildid']}) has been resigned for {device}, saving SHSH blobs.")
 
-                    await self.utils.update_auto_saver_frequency() # Set blob saver frequency back to 3 hours
-                    tss.auto_blob_saver.cancel() # Restart auto blob saver
-                    await asyncio.sleep(1)
-                    tss.auto_blob_saver.start()
+                    self.utils.saving_blobs = True
+                    async with aiosqlite.connect('Data/autotss.db') as db, db.execute('SELECT * from autotss WHERE enabled = ?', (True,)) as cursor:
+                        data = await cursor.fetchall()
 
+                    start_time = await asyncio.to_thread(time.time)
+                    data = await asyncio.gather(*[self.utils.sem_call(self.utils.save_user_blobs, user_data[0], json.loads(user_data[1])) for user_data in data])
+                    finish_time = round(await asyncio.to_thread(time.time) - start_time)
+
+                    self.utils.saving_blobs = False
+                    blobs_saved = sum(user['blobs_saved'] for user in data)
+                    devices_saved = sum(user['devices_saved'] for user in data)
+
+                    if blobs_saved > 0:
+                        description = ' '.join((
+                            f"Saved {blobs_saved} SHSH blob{'s' if blobs_saved > 1 else ''}",
+                            f"for {devices_saved} device{'s' if devices_saved > 1 else ''}",
+                            f"in {finish_time} second{'s' if finish_time != 1 else ''}."
+                        ))
+
+                    else:
+                        description = 'All SHSH blobs have already been saved.'
+
+                    print(f"[AUTO] {description}")
+                    await asyncio.sleep(300)
                     return
+
             else:
                 self._api[device] = api[device]
 
-        await asyncio.sleep(30)
+        await asyncio.sleep(300)
 
     @commands.Cog.listener()
     async def on_guild_join(self, guild: discord.Guild) -> None:
@@ -164,7 +184,6 @@ class EventsCog(commands.Cog, name='Events'):
     @commands.Cog.listener()
     async def on_ready(self) -> None:
         await self.utils.update_device_count()
-        await self.utils.update_auto_saver_frequency()
         print('AutoTSS is now online.')
 
     @commands.Cog.listener()

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -61,12 +61,12 @@ class MiscCog(commands.Cog, name='Miscellaneous'):
 
         embed = discord.Embed(title='Pong!', description='Testing ping...')
         embed.set_thumbnail(url=self.bot.user.display_avatar.with_static_format('png').url)
-        embed.set_footer(text=ctx.message.author.name, icon_url=ctx.message.author.display_avatar.with_static_format('png').url)
+        embed.set_footer(text=ctx.author.name, icon_url=ctx.author.display_avatar.with_static_format('png').url)
 
-        time = await self.datetime.utcnow()
+        current_time = await self.datetime.utcnow()
         message = await ctx.reply(embed=embed)
 
-        embed.description = f'Ping: `{round((await self.datetime.utcnow() - time).total_seconds() * 1000)}ms`'
+        embed.description = f'Ping: `{round((await self.datetime.utcnow() - current_time).total_seconds() * 1000)}ms`'
         await message.edit(embed=embed)
 
     @commands.command(help='General info on AutoTSS.')

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -1,4 +1,3 @@
-from aioify import aioify
 from datetime import datetime
 from discord.ext import commands
 
@@ -12,7 +11,7 @@ import time
 class MiscCog(commands.Cog, name='Miscellaneous'):
     def __init__(self, bot):
         self.bot = bot
-        self.datetime = aioify(datetime, name='datetime')
+
         self.utils = self.bot.get_cog('Utilities')
 
     @commands.command(help='Set the command prefix for AutoTSS.')
@@ -67,10 +66,10 @@ class MiscCog(commands.Cog, name='Miscellaneous'):
         embed.set_thumbnail(url=self.bot.user.display_avatar.with_static_format('png').url)
         embed.set_footer(text=ctx.author.name, icon_url=ctx.author.display_avatar.with_static_format('png').url)
 
-        current_time = await self.datetime.utcnow()
+        current_time = await asyncio.to_thread(datetime.utcnow)
         message = await ctx.reply(embed=embed)
 
-        embed.description = f'Ping: `{round((await self.datetime.utcnow() - current_time).total_seconds() * 1000)}ms`'
+        embed.description = f'Ping: `{round((await asyncio.to_thread(datetime.utcnow) - current_time).total_seconds() * 1000)}ms`'
         await message.edit(embed=embed)
 
     @commands.command(help='General info on AutoTSS.')

--- a/cogs/tss.py
+++ b/cogs/tss.py
@@ -318,7 +318,7 @@ class TSSCog(commands.Cog, name='TSS'):
                 f"in **{finish_time} second{'s' if finish_time != 1 else ''}**."
             ))
         else:
-            embed.description = 'No SHSH Blobs need to be saved.'
+            embed.description = 'No SHSH blobs need to be saved.\n\n*Tip: AutoTSS will automatically save SHSH blobs for you, no command necessary!*'
 
         await message.edit(embed=embed)
 

--- a/cogs/tss.py
+++ b/cogs/tss.py
@@ -285,6 +285,8 @@ class TSSCog(commands.Cog, name='TSS'):
             return
 
         self.utils.saving_blobs = True
+        await self.bot.change_presence(activity=discord.Game(name='Ping me for help! | Currently saving SHSH blobs!'))
+
         embed = discord.Embed(title='Save Blobs', description='Saving SHSH blobs for all of your devices...')
         embed.set_footer(text=ctx.author.display_name, icon_url=ctx.author.display_avatar.with_static_format('png').url)
         message = await ctx.reply(embed=embed)
@@ -307,6 +309,7 @@ class TSSCog(commands.Cog, name='TSS'):
         else:
             embed.description = 'All SHSH blobs have already been saved.\n\n*Tip: AutoTSS will automatically save SHSH blobs for you, no command necessary!*'
 
+        await self.utils.update_device_count()
         await message.edit(embed=embed)
 
 

--- a/cogs/tss.py
+++ b/cogs/tss.py
@@ -159,14 +159,14 @@ class TSSCog(commands.Cog, name='TSS'):
             device_options = [discord.SelectOption(
                 label='All',
                 description=f"Devices: {len(devices)} | Total SHSH blob{'s' if total_blobs != 1 else ''} saved: {total_blobs}",
-                emoji='📱'
+                emoji=':mobile_phone:'
             )]
 
             for device in devices:
                 device_options.append(discord.SelectOption(
                     label=device['name'],
                     description=f"ECID: {await self.utils.censor_ecid(device['ecid'])} | SHSH blob{'s' if len(device['saved_blobs']) != 1 else ''} saved: {len(device['saved_blobs'])}",
-                    emoji='📱'
+                    emoji=':mobile_phone:'
                 ))
 
             embed = discord.Embed(title='Download Blobs', description="Choose which device you'd like to download SHSH blobs for")

--- a/cogs/tss.py
+++ b/cogs/tss.py
@@ -159,14 +159,14 @@ class TSSCog(commands.Cog, name='TSS'):
             device_options = [discord.SelectOption(
                 label='All',
                 description=f"Devices: {len(devices)} | Total SHSH blob{'s' if total_blobs != 1 else ''} saved: {total_blobs}",
-                emoji=':mobile_phone:'
+                emoji='📱'
             )]
 
             for device in devices:
                 device_options.append(discord.SelectOption(
                     label=device['name'],
                     description=f"ECID: {await self.utils.censor_ecid(device['ecid'])} | SHSH blob{'s' if len(device['saved_blobs']) != 1 else ''} saved: {len(device['saved_blobs'])}",
-                    emoji=':mobile_phone:'
+                    emoji='📱'
                 ))
 
             embed = discord.Embed(title='Download Blobs', description="Choose which device you'd like to download SHSH blobs for")

--- a/cogs/tss.py
+++ b/cogs/tss.py
@@ -320,11 +320,15 @@ class TSSCog(commands.Cog, name='TSS'):
             await db.execute('UPDATE autotss SET devices = ? WHERE user = ?', (json.dumps([d['device'] for d in data]), ctx.author.id))
             await db.commit()
 
-        embed.description = ' '.join((
-            f"Saved **{blobs_saved} SHSH blob{'s' if blobs_saved != 1 else ''}**",
-            f"for **{devices_saved} device{'s' if devices_saved != 1 else ''}**",
-            f"in **{finish_time} second{'s' if finish_time != 1 else ''}**."
-        ))
+        if len(blobs_saved) > 0:
+            embed.description = ' '.join((
+                f"Saved **{blobs_saved} SHSH blob{'s' if blobs_saved != 1 else ''}**",
+                f"for **{devices_saved} device{'s' if devices_saved != 1 else ''}**",
+                f"in **{finish_time} second{'s' if finish_time != 1 else ''}**."
+            ))
+        else:
+            embed.description = 'No SHSH Blobs need to be saved.'
+
         await message.edit(embed=embed)
 
     @tss_group.command(name='downloadall', help='Download SHSH blobs for all devices in AutoTSS.')

--- a/cogs/tss.py
+++ b/cogs/tss.py
@@ -333,13 +333,7 @@ class TSSCog(commands.Cog, name='TSS'):
         await ctx.message.delete()
 
         async with aiosqlite.connect('Data/autotss.db') as db, db.execute('SELECT devices from autotss') as cursor:
-            all_devices = await cursor.fetchall()
-
-        num_devices = int()
-        for user_devices in all_devices:
-            devices = json.loads(user_devices[0])
-
-            num_devices += len(devices)
+            num_devices = sum(len(json.loads(devices[0])) for devices in await cursor.fetchall())
 
         if num_devices == 0:
             embed = discord.Embed(title='Error', description='There are no devices added to AutoTSS.')
@@ -363,8 +357,7 @@ class TSSCog(commands.Cog, name='TSS'):
         if url is None:
             embed = discord.Embed(title='Error', description='There are no SHSH blobs saved in AutoTSS.')
         else:
-            embed = discord.Embed(title='Download All Blobs', description=f'[Click here]({url}).')
-            embed.set_footer(text=ctx.author.display_name, icon_url=ctx.author.display_avatar.with_static_format('png').url)
+            embed.description = f'[Click here]({url}).'
 
         await message.edit(embed=embed)
 

--- a/cogs/tss.py
+++ b/cogs/tss.py
@@ -302,8 +302,6 @@ class TSSCog(commands.Cog, name='TSS'):
             await ctx.reply(embed=embed)
             return
 
-        self.utils.saving_blobs = True
-
         embed = discord.Embed(title='Save Blobs', description='Saving SHSH blobs for all of your devices...')
         embed.set_footer(text=ctx.author.display_name, icon_url=ctx.author.display_avatar.with_static_format('png').url)
         message = await ctx.reply(embed=embed)
@@ -321,8 +319,6 @@ class TSSCog(commands.Cog, name='TSS'):
         async with aiosqlite.connect('Data/autotss.db') as db:        
             await db.execute('UPDATE autotss SET devices = ? WHERE user = ?', (json.dumps([d['device'] for d in data]), ctx.author.id))
             await db.commit()
-
-        self.utils.saving_blobs = False
 
         embed.description = ' '.join((
             f"Saved **{blobs_saved} SHSH blob{'s' if blobs_saved != 1 else ''}**",

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -41,7 +41,7 @@ class UtilsCog(commands.Cog, name='Utilities'):
         else:
             for ecid in ecids:
                 try:
-                    await asyncio.to_thread(shutil.copytree, f'Data/Blobs/{ecid}', f'{tmpdir}/SHSH Blobs/{ecid}'))
+                    await asyncio.to_thread(shutil.copytree, f'Data/Blobs/{ecid}', f'{tmpdir}/SHSH Blobs/{ecid}')
                 except FileNotFoundError:
                     pass
 

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -406,11 +406,8 @@ class UtilsCog(commands.Cog, name='Utilities'):
                 continue
 
             async with aiofiles.tempfile.TemporaryDirectory() as tmpdir:
-                manifest = await self.bot.loop.run_in_executor(self.shsh_pool, self.get_manifest, firm['url'], tmpdir)
-                if manifest == False:
-                    saved_blob = False
-                else:
-                    saved_blob = await self._save_blob(device, firm, manifest, tmpdir)
+                manifest = await asyncio.to_thread(self.get_manifest, firm['url'], tmpdir)
+                saved_blob = await self._save_blob(device, firm, manifest, tmpdir) if manifest != False else False
 
             if saved_blob is True:
                 device['saved_blobs'].append({x:y for x,y in firm.items() if x != 'url'})

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -282,12 +282,7 @@ class UtilsCog(commands.Cog, name='Utilities'):
 
     async def update_device_count(self) -> None:
         async with aiosqlite.connect('Data/autotss.db') as db, db.execute('SELECT devices from autotss WHERE enabled = ?', (True,)) as cursor:
-            all_devices = (await cursor.fetchall())
-
-        num_devices = int()
-        for user_devices in all_devices:
-            devices = json.loads(user_devices[0])
-            num_devices += len(devices)
+            num_devices = sum(len(json.loads(devices[0])) for devices in await cursor.fetchall())
 
         await self.bot.change_presence(activity=discord.Game(name=f"Ping me for help! | Saving SHSH blobs for {num_devices} device{'s' if num_devices != 1 else ''}."))
 

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -224,7 +224,7 @@ class UtilsCog(commands.Cog, name='Utilities'):
         notes = (
             'There is a limit of **10 devices per user**.',
             "You **must** share a server with AutoTSS, or else **AutoTSS won't automatically save SHSH blobs for you**.",
-            'AutoTSS checks for new versions to save SHSH blobs for **every 3 hours**.'
+            'AutoTSS checks for new versions to save SHSH blobs for **every 5 minutes**.'
         )
 
         embed = {

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -285,17 +285,6 @@ class UtilsCog(commands.Cog, name='Utilities'):
 
         return discord.Embed.from_dict(embed)
 
-    async def update_auto_saver_frequency(self, time: int=10800) -> None:
-        async with aiosqlite.connect('Data/autotss.db') as db:
-            async with db.execute('SELECT time FROM auto_frequency') as cursor:
-                if await cursor.fetchone() is None:
-                    sql = 'INSERT INTO auto_frequency(time) VALUES(?)'
-                else:
-                    sql = 'UPDATE auto_frequency SET time = ?'
-
-            await db.execute(sql, (time,))
-            await db.commit()
-
     async def update_device_count(self) -> None:
         async with aiosqlite.connect('Data/autotss.db') as db, db.execute('SELECT devices from autotss WHERE enabled = ?', (True,)) as cursor:
             all_devices = (await cursor.fetchall())

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -1,4 +1,3 @@
-from aioify import aioify
 from discord.ext import commands
 from typing import Optional, Union
 
@@ -11,16 +10,12 @@ import json
 import os
 import remotezip
 import shutil
-import time
 
 
 class UtilsCog(commands.Cog, name='Utilities'):
     def __init__(self, bot):
         self.bot = bot
-        self.os = aioify(os, name='os')
         self.saving_blobs = False
-        self.shutil = aioify(shutil, name='shutil')
-        self.time = aioify(time, name='time')
 
     @property
     def invite(self) -> str:
@@ -38,22 +33,22 @@ class UtilsCog(commands.Cog, name='Utilities'):
         return resp.splitlines()[-1].split(':', 1)[1][1:]
 
     async def backup_blobs(self, tmpdir: str, *ecids: list[str]):
-        await self.os.mkdir(f'{tmpdir}/SHSH Blobs')
+        await asyncio.to_thread(os.mkdir, f'{tmpdir}/SHSH Blobs')
 
         if len(ecids) == 1:
             for firm in glob.glob(f'Data/Blobs/{ecids[0]}/*'):
-                await self.shutil.copytree(firm, f"{tmpdir}/SHSH Blobs/{firm.split('/')[-1]}")
+                await asyncio.to_thread(shutil.copytree, firm, f"{tmpdir}/SHSH Blobs/{firm.split('/')[-1]}")
         else:
             for ecid in ecids:
                 try:
-                    await self.shutil.copytree(f'Data/Blobs/{ecid}', f'{tmpdir}/SHSH Blobs/{ecid}')
+                    await asyncio.to_thread(shutil.copytree, f'Data/Blobs/{ecid}', f'{tmpdir}/SHSH Blobs/{ecid}'))
                 except FileNotFoundError:
                     pass
 
         if len(glob.glob(f'{tmpdir}/SHSH Blobs/*')) == 0:
             return
 
-        await self.shutil.make_archive(f'{tmpdir}_blobs', 'zip', tmpdir)
+        await asyncio.to_thread(shutil.make_archive, f'{tmpdir}_blobs', 'zip', tmpdir)
         return await self._upload_file(f'{tmpdir}_blobs.zip', 'shsh_blobs.zip')
 
     async def censor_ecid(self, ecid: str) -> str: return ('*' * len(ecid))[:-4] + ecid[-4:]
@@ -361,7 +356,7 @@ class UtilsCog(commands.Cog, name='Utilities'):
                 return True
 
             elif len(glob.glob(f'{path}/*.shsh*')) > 0:
-                await self.os.remove(*[f for f in glob.glob(f'{tmpdir}/*.shsh*')])
+                await asyncio.to_thread(os.remove, *[f for f in glob.glob(f'{tmpdir}/*.shsh*')])
 
             args.append('-g')
             for gen in generators:
@@ -374,11 +369,11 @@ class UtilsCog(commands.Cog, name='Utilities'):
 
                 args.pop(-1)
 
-        if not await self.os.path.isdir(path):
-            await self.os.makedirs(path)
+        if not await asyncio.to_thread(os.path.isdir, path):
+            await asyncio.to_thread(os.makedirs, path)
 
         for blob in glob.glob(f'{tmpdir}/*.shsh*'):
-            await self.os.rename(blob, f"{path}/{blob.split('/')[-1]}")
+            await asyncio.to_thread(os.rename, blob, f"{path}/{blob.split('/')[-1]}")
 
         return True
 

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -438,5 +438,9 @@ class UtilsCog(commands.Cog, name='Utilities'):
 
         return user_stats
 
+    async def sem_call(self, func, *args):
+        async with self.sem:
+            return await func(*args)
+
 def setup(bot):
     bot.add_cog(UtilsCog(bot))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-aioify
 aiofiles
 aiosqlite
 git+git://github.com/Pycord-Development/pycord@master


### PR DESCRIPTION
Changes
- Multithreaded SHSH blob saving
    - (\*hugely* speeds up the SHSH Blob saving process, around 7 SHSH blobs saved/second when testing locally)
- `b!tss save`, `b!tss saveall` and the automatic blob saver have all been rewritten
- `aioify` dependency removed in favor of `asyncio.to_thread()`
- `b!uptime` command added