### PR TITLE
feat(manifest): get manifest directly instead of from the IPSW file

### DIFF
--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -569,7 +569,7 @@ class UtilsCog(commands.Cog, name='Utilities'):
                 continue
 
             async with aiofiles.tempfile.TemporaryDirectory() as tmpdir:
-                manifest = await self._get_manifest(firm['url'], tmpdir)
+                manifest = await (await asyncio.to_thread(self._get_manifest, firm['url'], tmpdir))
                 saved_blob = (
                     await self._save_blob(device, firm, str(manifest), manifest.parent)
                     if manifest != False

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -395,7 +395,7 @@ class UtilsCog(commands.Cog, name='Utilities'):
                 )
         except (remotezip.RemoteIOError, StopIteration):
             return False
-        
+
         manifest_path = pathlib.Path(path) / 'manifest.plist'
         with manifest_path.open('wb') as f:
             f.write(manifest)


### PR DESCRIPTION
For some reason you can get the `BuildManifest.plist` of an IPSW by just replacing the ipsw part in the url with `BuildManifest.plist`:
```diff
- https://updates.cdn-apple.com/2021FallSeed/fullrestores/002-20336/F83338ED-388D-4819-89D6-B6F9EC98E72B/iPhone11,8,iPhone12,1_15.2_19C5026i_Restore.ipsw
+ https://updates.cdn-apple.com/2021FallSeed/fullrestores/002-20336/F83338ED-388D-4819-89D6-B6F9EC98E72B/BuildManifest.plist
```
```bash
$ pzb -g BuildManifest.plist https://updates.cdn-apple.com/2021FallSeed/fullrestores/002-20336/F83338ED-388D-4819-89D6-B6F9EC98E72B/iPhone11,8,iPhone12,1_15.2_19C5026i_Restore.ipsw 
Version: 855c0f9eaba828d4c20b9261c5a27f959fe318bb - 1050
libfragmentzip version: 0.1165-ae229cefdad81f0b311ca55840b0769b7769e257
init pzb: https://updates.cdn-apple.com/2021FallSeed/fullrestores/002-20336/F83338ED-388D-4819-89D6-B6F9EC98E72B/iPhone11,8,iPhone12,1_15.2_19C5026i_Restore.ipsw
init done
getting: BuildManifest.plist
100% [===================================================================================================>]
download succeeded

$ curl -L -o BuildManifest2.plist https://updates.cdn-apple.com/2021FallSeed/fullrestores/002-20336/F83338ED-388D-4819-89D6-B6F9EC98E72B/BuildManifest.plist 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  757k  100  757k    0     0   644k      0  0:00:01  0:00:01 --:--:--  649k

$ cmp BuildManifest.plist BuildManifest2.plist && echo "identical"
identical
```

This pull request modifies the `_get_manifest()` function to try getting the BuildManifest.plist directly before getting it from the IPSW.

Blobs save about 5 seconds faster/version/device from my limited testing.